### PR TITLE
Allow modal screens to have transparent backdrops

### DIFF
--- a/src/twg/ui/styles.tcss
+++ b/src/twg/ui/styles.tcss
@@ -1,6 +1,5 @@
 /* Global Styles */
 Screen {
-    background: $background;
     color: $text;
 }
 


### PR DESCRIPTION
Small suggested change: the nice thing about Textual's `ModalScreen` is it will allow the background to show through by default, but I noticed `twg` isn't doing that with its modals. This wee change will allow that. So we go from:

<img width="899" height="811" alt="Screenshot 2025-12-10 at 10 43 54" src="https://github.com/user-attachments/assets/e8afd33b-9ac4-4ac2-81da-388814804637" />

to:

<img width="899" height="811" alt="Screenshot 2025-12-10 at 10 44 02" src="https://github.com/user-attachments/assets/4a77876f-1c33-4114-a86b-b62fe485699a" />

when doing a search, for example.